### PR TITLE
.NET 10 and FluentValidation 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [2.0.0](https://github.com/sitkoru/Sitko.FluentValidation/compare/1.5.0...2.0.0) (2026-05-18)
+
+
+### Features
+
+* support only `net8.0` and `net10.0`
+* upgrade to `FluentValidation 12`
+
+### BREAKING CHANGES
+
+* dropped support for previously supported target frameworks; this release requires `net8.0` or `net10.0`
+
 # [1.5.0](https://github.com/sitkoru/Sitko.FluentValidation/compare/1.4.0...1.5.0) (2022-10-20)
 
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 Set of extensions for [FluentValidation](https://fluentvalidation.net/) library
 
+Supports `net8.0` and `net10.0`.
+
 # Installation
 
 ```
 dotnet add package Sitko.FluentValidation
 ```
 
-Register in DI in `Startup.cs` or `Program.cs`
+Register in DI in `Program.cs` or your service registration setup:
 
 ```c#
 services.AddFluentValidationExtensions();
@@ -22,15 +24,14 @@ IFluentGraphValidator allows to recursively validate model graph.
 
 ```c#
 public class MyService {
-    
-    private IFluentGraphValidator _fluentGraphValidator;
+    private readonly IFluentGraphValidator fluentGraphValidator;
 
     public MyService(IFluentGraphValidator fluentGraphValidator) {
-        _fluentGraphValidator = fluentGraphValidator;
+        this.fluentGraphValidator = fluentGraphValidator;
     }
-    
+
     public async Task SaveDataAsync(MyData data, CancellationToken cancellationToken = default) {
-        var result = await _fluentGraphValidator.TryValidateModelAsync(data, cancellationToken);
+        var result = await fluentGraphValidator.TryValidateModelAsync(data, cancellationToken);
         if(result.IsValid) {
             // validation was successfull
         }

--- a/docs/superpowers/plans/2026-05-18-net10-fv12-upgrade.md
+++ b/docs/superpowers/plans/2026-05-18-net10-fv12-upgrade.md
@@ -1,0 +1,251 @@
+# Sitko.FluentValidation net8/net10 and FluentValidation 12 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `Sitko.FluentValidation` to support only `net8.0` and `net10.0`, upgrade it to `FluentValidation 12`, and verify graph validation works consistently on both TFMs.
+
+**Architecture:** Keep the package structure intact and make the smallest source changes needed for `FluentValidation 12` compatibility. Use TFM-specific `Microsoft.Extensions.*` references, multi-target the tests, and add focused regression coverage for DI and graph validation behavior.
+
+**Tech Stack:** .NET 8, .NET 10, FluentValidation 12, Microsoft.Extensions.DependencyInjection, Sitko.Core.Xunit, xUnit
+
+---
+
+### Task 1: Update Library Target Frameworks and Dependency Matrix
+
+**Files:**
+- Modify: `src/Sitko.FluentValidation/Sitko.FluentValidation.csproj`
+- Test: `tests/Sitko.FluentValidation.Tests/FluentGraphValidatorTests.cs`
+
+- [ ] **Step 1: Write the failing compatibility test expectation**
+
+Document the compatibility target by adding a new test name to the test file that will assert FV12-compatible graph validation behavior once implemented. Reuse the existing test style from `FluentGraphValidatorTests` and add a focused test that resolves `FluentGraphValidator` and validates a simple invalid `FooModel`.
+
+```csharp
+[Fact]
+public async Task ValidateParentOnAllSupportedTfms()
+{
+    var scope = await GetScopeAsync();
+    var validator = scope.GetService<FluentGraphValidator>();
+    var foo = new FooModel();
+
+    var result = await validator.TryValidateModelAsync(foo);
+
+    result.IsValid.Should().BeFalse();
+    result.Results.Should().ContainSingle();
+}
+```
+
+- [ ] **Step 2: Run the targeted test on `net8.0` before library changes**
+
+Run: `dotnet test --framework net8.0 --filter "FullyQualifiedName~ValidateParentOnAllSupportedTfms"`
+
+Expected: either PASS immediately because behavior already exists, or FAIL only if the current package graph reveals the FV12 issue through the new test shape. Record the outcome in your task notes before proceeding.
+
+- [ ] **Step 3: Update `src/Sitko.FluentValidation/Sitko.FluentValidation.csproj`**
+
+Make these edits:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Authors>George Drak</Authors>
+    <Company>Sitko.Ru</Company>
+    <Product>Sitko.FluentValidation</Product>
+    <Description>Sitko.FluentValidation is set of extensions for FluentValidation</Description>
+    <Summary>Sitko.FluentValidation is set of extensions for FluentValidation</Summary>
+    <Copyright>Copyright © Sitko.ru 2021</Copyright>
+    <RepositoryUrl>https://github.com/sitkoru/Sitko.FluentValidation</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/sitkoru/Sitko.FluentValidation</PackageProjectUrl>
+    <PackageIcon>packageIcon.png</PackageIcon>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
+    <None Include="..\..\packageIcon.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>
+```
+
+Remove the old legacy-target package branches and the `IsExternalInit` dependency if the project no longer needs it after dropping pre-.NET 8 TFMs.
+
+- [ ] **Step 4: Run restore and build for the solution**
+
+Run: `dotnet build "Sitko.FluentValidation.sln"`
+
+Expected: the project restores with the new package graph and either builds cleanly or exposes the exact FV12 compatibility errors that must be fixed in the next task.
+
+- [ ] **Step 5: Commit the dependency/TFM baseline**
+
+```bash
+git add src/Sitko.FluentValidation/Sitko.FluentValidation.csproj tests/Sitko.FluentValidation.Tests/FluentGraphValidatorTests.cs
+git commit -m "build: target net8 and net10 with fluentvalidation 12"
+```
+
+### Task 2: Make Library and Tests FluentValidation 12 Compatible
+
+**Files:**
+- Modify: `src/Sitko.FluentValidation/**/*.cs`
+- Modify: `tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj`
+- Modify: `tests/Sitko.FluentValidation.Tests/ValidationTestScope.cs`
+- Modify: `tests/Sitko.FluentValidation.Tests/FluentGraphValidatorTests.cs`
+- Test: `tests/Sitko.FluentValidation.Tests/**/*.cs`
+
+- [ ] **Step 1: Multi-target the test project and preserve existing references**
+
+Update `tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj` to:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Sitko.Core.Xunit" Version="11.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sitko.FluentValidation\Sitko.FluentValidation.csproj" />
+  </ItemGroup>
+
+</Project>
+```
+
+- [ ] **Step 2: Run the existing graph validator suite on `net8.0` and observe failures**
+
+Run: `dotnet test --framework net8.0 "tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj"`
+
+Expected: this should expose the concrete FluentValidation 12 source or behavior incompatibilities that need fixing.
+
+- [ ] **Step 3: Fix FluentValidation 12 compatibility in the library with minimal source changes**
+
+Inspect the files under `src/Sitko.FluentValidation/` and update only the failing compatibility points. Typical expected touchpoints are:
+
+- validator resolution code
+- validation context creation
+- graph traversal code that depends on FluentValidation internals or old interfaces
+
+Keep the public API shape stable unless a FluentValidation 12 change makes that impossible.
+
+- [ ] **Step 4: Add a focused regression test for DI + graph validation resolution**
+
+Extend `FluentGraphValidatorTests.cs` with a test that proves validators are discovered and applied through `AddFluentValidationExtensions()` in the same way consumers rely on them.
+
+Use a pattern like:
+
+```csharp
+[Fact]
+public async Task ValidatorResolvedFromDiIsAppliedByGraphValidator()
+{
+    var scope = await GetScopeAsync();
+    var graphValidator = scope.GetService<FluentGraphValidator>();
+    var validator = scope.GetService<global::FluentValidation.IValidator<FooModel>>();
+    var foo = new FooModel();
+
+    var directResult = await validator.ValidateAsync(foo);
+    var graphResult = await graphValidator.TryValidateModelAsync(foo);
+
+    directResult.IsValid.Should().BeFalse();
+    graphResult.IsValid.Should().BeFalse();
+}
+```
+
+- [ ] **Step 5: Run the test suite on both TFMs**
+
+Run:
+
+```bash
+dotnet test --framework net8.0 "tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj"
+dotnet test --framework net10.0 "tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj"
+```
+
+Expected: both commands pass with identical logical behavior.
+
+- [ ] **Step 6: Commit the compatibility fixes**
+
+```bash
+git add src/Sitko.FluentValidation tests/Sitko.FluentValidation.Tests
+git commit -m "fix: align graph validation with fluentvalidation 12"
+```
+
+### Task 3: Update Release Metadata, Verify Packaging, and Create Breaking Release Commit
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `release.config.js` (only if needed for current release flow)
+- Test: `Sitko.FluentValidation.sln`
+
+- [ ] **Step 1: Update README supported frameworks and usage guidance**
+
+Edit `README.md` so it no longer implies support for removed TFMs and still documents `services.AddFluentValidationExtensions();` correctly for current .NET usage.
+
+- [ ] **Step 2: Add changelog entry that makes the breaking change explicit**
+
+Add a new top entry to `CHANGELOG.md` that states:
+
+- support reduced to `net8.0` and `net10.0`
+- upgraded to `FluentValidation 12`
+- this is a breaking release / major version bump
+
+- [ ] **Step 3: Verify pack works**
+
+Run: `dotnet pack "Sitko.FluentValidation.sln" -c Release`
+
+Expected: the package and symbols pack successfully.
+
+- [ ] **Step 4: Run final full verification**
+
+Run:
+
+```bash
+dotnet test --framework net8.0 "tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj"
+dotnet test --framework net10.0 "tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj"
+dotnet pack "Sitko.FluentValidation.sln" -c Release
+```
+
+Expected: all commands succeed.
+
+- [ ] **Step 5: Create the final breaking conventional commit**
+
+This commit MUST trigger a major version bump in the conventional-commit-based release flow.
+
+Use:
+
+```bash
+git add README.md CHANGELOG.md release.config.js
+git commit -m "feat!: support only net8 and net10 with fluentvalidation 12"
+```
+
+If the implementation changes from Tasks 1 and 2 are not yet included in a breaking commit chain acceptable for the release flow, include the relevant files in this final commit as well so the released history clearly reflects the breaking change.

--- a/docs/superpowers/specs/2026-05-18-net10-fv12-design.md
+++ b/docs/superpowers/specs/2026-05-18-net10-fv12-design.md
@@ -1,0 +1,153 @@
+# Sitko.FluentValidation .NET 10 and FluentValidation 12 Design
+
+## Goal
+
+Update `Sitko.FluentValidation` to support only `net8.0` and `net10.0`, migrate the package to `FluentValidation 12`, refresh supporting dependencies, and ensure graph validation and DI registration behave consistently across both target frameworks.
+
+## Current State
+
+- Library targets `netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0`.
+- Tests target only `net8.0`.
+- Package references are managed directly inside project files.
+- `Sitko.FluentValidation` currently references `FluentValidation 11.9.0`.
+- The consuming repo `Sitko.Core` has already exposed a compatibility risk when `Sitko.FluentValidation 1.12.0` is used together with `FluentValidation 12`.
+
+## Recommended Approach
+
+Use a focused migration:
+
+1. Reduce supported TFMs to `net8.0;net10.0`.
+2. Upgrade `FluentValidation` to `12.x`.
+3. Keep `Microsoft.Extensions.*` references TFM-specific:
+   - `8.x` for `net8.0`
+   - `10.x` for `net10.0`
+4. Multi-target the tests to `net8.0;net10.0`.
+5. Fix any source or behavioral incompatibilities in the library rather than hiding them in tests.
+
+This keeps the repo aligned with current consumers while minimizing unrelated modernization work.
+
+## Alternatives Considered
+
+### 1. Keep older TFMs and add `net10.0`
+
+This would preserve broader compatibility, but it keeps package management and validation behavior constrained by older targets that are no longer needed for the current goal.
+
+### 2. Update only TFMs and keep `FluentValidation 11`
+
+This would be lower risk short term, but it would not solve the real consumer compatibility problem that appears when downstream code uses `FluentValidation 12`.
+
+### 3. Full repository modernization
+
+This could include Central Package Management and wider cleanup, but it would increase scope without directly improving the migration outcome.
+
+## Architecture Impact
+
+The public role of the package does not change: it still provides graph validation and DI registration helpers around FluentValidation.
+
+The main change is compatibility alignment:
+
+- compile-time compatibility with `net8.0` and `net10.0`
+- runtime compatibility with `FluentValidation 12`
+- explicit test coverage for both supported TFMs
+
+No new subsystems or package structure changes are planned.
+
+## File-Level Design
+
+### `src/Sitko.FluentValidation/Sitko.FluentValidation.csproj`
+
+Change target frameworks from legacy multi-targeting to:
+
+- `net8.0;net10.0`
+
+Update package references:
+
+- `FluentValidation` -> `12.x`
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `Microsoft.Extensions.Logging.Abstractions`
+- `Microsoft.Extensions.Options.ConfigurationExtensions`
+- `Microsoft.SourceLink.GitHub`
+
+Retain TFM-specific `Microsoft.Extensions.*` references so `net8.0` stays on the .NET 8 package line while `net10.0` uses the .NET 10 package line.
+
+Remove now-unneeded legacy-target support branches and any packages that only existed for older TFMs if they are no longer required.
+
+### `tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj`
+
+Convert tests to `net8.0;net10.0`.
+
+Refresh `Sitko.Core.Xunit` if needed for compatibility with the final test package graph.
+
+### `tests/Sitko.FluentValidation.Tests/*`
+
+Keep the current test intent, but add or adjust tests to ensure:
+
+- graph validation finds validators correctly
+- nested object validation still works
+- DI registration still resolves the expected validator/graph validator services
+- behavior is the same on `net8.0` and `net10.0`
+
+If the existing suite does not cover the downstream failure mode already observed in `Sitko.Core`, add a focused regression test for it here.
+
+### `README.md`
+
+Update the documented supported frameworks and package usage examples if they imply older TFMs.
+
+### `CHANGELOG.md`
+
+Add an entry describing:
+
+- support limited to `net8.0` and `net10.0`
+- `FluentValidation 12` support
+- dependency refresh
+
+Because dropping older TFMs is a breaking change, the eventual release should be treated as a breaking release.
+
+## Compatibility Strategy
+
+The important compatibility boundary is between this package and FluentValidation itself.
+
+The migration should assume that any code paths relying on internal or behavioral details of FluentValidation 11 may need adjustment for FluentValidation 12. The library should be updated to work natively with FluentValidation 12 rather than depending on downstream workarounds.
+
+The package should continue to expose the same conceptual API unless a FluentValidation 12 change makes that impossible. If a public API change becomes necessary, document it explicitly in the changelog.
+
+## Testing Strategy
+
+Required verification:
+
+- `dotnet test --framework net8.0`
+- `dotnet test --framework net10.0`
+- `dotnet pack` to confirm packaging still succeeds
+
+Testing should specifically cover:
+
+- direct validator resolution from DI
+- graph validation over nested models and collections
+- identical pass/fail behavior across `net8.0` and `net10.0`
+
+If a new regression test is added for the issue seen in `Sitko.Core`, it should fail before the compatibility fix and pass after it.
+
+## Risks
+
+### FluentValidation 12 breaking changes
+
+Most likely risk area. The implementation may require source changes in graph validation logic or DI registration helpers.
+
+### Test dependency skew
+
+If the test project pulls in packages that pin older FluentValidation-related behavior indirectly, results may be misleading. The effective package graph should be checked if behavior is inconsistent.
+
+### Over-scoping the migration
+
+Avoid unrelated cleanup such as CPM conversion or broad refactoring unless directly required to complete the migration.
+
+## Success Criteria
+
+The migration is complete when all of the following are true:
+
+- library targets only `net8.0;net10.0`
+- library builds successfully on both TFMs
+- tests pass on both TFMs
+- package packs successfully
+- package behavior is compatible with `FluentValidation 12`
+- no downstream-style workaround is needed to make graph validation behave correctly

--- a/docs/superpowers/specs/2026-05-18-net10-fv12-design.md
+++ b/docs/superpowers/specs/2026-05-18-net10-fv12-design.md
@@ -101,7 +101,19 @@ Add an entry describing:
 - `FluentValidation 12` support
 - dependency refresh
 
-Because dropping older TFMs is a breaking change, the eventual release should be treated as a breaking release.
+Because dropping older TFMs is a breaking change, the eventual release must be versioned as a major release rather than a minor or patch release.
+
+## Versioning Strategy
+
+This migration must produce a major version bump.
+
+Reasons:
+
+- supported target frameworks are being reduced
+- consumers pinned to older TFMs will no longer be able to install the new version safely
+- `FluentValidation 12` compatibility may imply consumer-visible integration changes
+
+Release and changelog metadata should make the breaking nature explicit so package consumers do not receive the upgrade as a non-breaking update.
 
 ## Compatibility Strategy
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/src/Sitko.FluentValidation/Graph/FluentGraphValidator.cs
+++ b/src/Sitko.FluentValidation/Graph/FluentGraphValidator.cs
@@ -13,15 +13,15 @@ public class FluentGraphValidator : IFluentGraphValidator
     private static readonly ConcurrentDictionary<Type, Type?> TypesValidators = new();
     private readonly ILogger<FluentGraphValidator> logger;
     private readonly IOptions<FluentGraphValidatorOptions> options;
-    private readonly IServiceScope serviceScope;
+    private readonly IServiceProvider serviceProvider;
     private static readonly ConcurrentDictionary<string, bool> IgnoredPropertiesCache = new();
 
     public FluentGraphValidator(IServiceProvider serviceProvider, ILogger<FluentGraphValidator> logger,
         IOptions<FluentGraphValidatorOptions> options)
     {
+        this.serviceProvider = serviceProvider;
         this.logger = logger;
         this.options = options;
-        serviceScope = serviceProvider.CreateScope();
     }
 
     public Task<ModelsValidationResult> TryValidateFieldAsync(
@@ -51,10 +51,10 @@ public class FluentGraphValidator : IFluentGraphValidator
         validatorSelector ??= ValidatorOptions.Global.ValidatorSelectors.DefaultValidatorSelectorFactory();
 
         var context = parent?.CloneForChildValidator(model, true, validatorSelector) ??
-                      new ValidationContext<object>(model, new PropertyChain(), validatorSelector)
-                      {
-                          RootContextData = { ["_FV_ServiceProvider"] = serviceScope.ServiceProvider }
-                      };
+                       new ValidationContext<object>(model, new PropertyChain(), validatorSelector)
+                       {
+                           RootContextData = { ["_FV_ServiceProvider"] = serviceProvider }
+                       };
 
         return context;
     }
@@ -74,7 +74,7 @@ public class FluentGraphValidator : IFluentGraphValidator
             formValidatorType = validatorType.MakeGenericType(model.GetType());
         }
 
-        var validator = serviceScope.ServiceProvider.GetService(formValidatorType) as IValidator;
+        var validator = serviceProvider.GetService(formValidatorType) as IValidator;
         if (validator is null)
         {
             logger.LogWarning(

--- a/src/Sitko.FluentValidation/Sitko.FluentValidation.csproj
+++ b/src/Sitko.FluentValidation/Sitko.FluentValidation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -22,29 +22,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.9.0" />
-    <PackageReference Include="IsExternalInit" Version="1.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md"/>
-    <None Include="..\..\packageIcon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
+    <None Include="..\..\packageIcon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/tests/Sitko.FluentValidation.Tests/FluentGraphValidatorTests.cs
+++ b/tests/Sitko.FluentValidation.Tests/FluentGraphValidatorTests.cs
@@ -47,6 +47,19 @@ public class FluentGraphValidatorTests : BaseTest<ValidationTestScope>
     }
 
     [Fact]
+    public async Task ValidateParentOnAllSupportedTfms()
+    {
+        var scope = await GetScopeAsync();
+        var validator = scope.GetService<FluentGraphValidator>();
+        var foo = new FooModel();
+
+        var result = await validator.TryValidateModelAsync(foo);
+
+        result.IsValid.Should().BeFalse();
+        result.Results.Should().ContainSingle();
+    }
+
+    [Fact]
     public async Task ValidateChild()
     {
         var scope = await GetScopeAsync();

--- a/tests/Sitko.FluentValidation.Tests/FluentGraphValidatorTests.cs
+++ b/tests/Sitko.FluentValidation.Tests/FluentGraphValidatorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentValidation;
 using Sitko.Core.Xunit;
 using Sitko.FluentValidation.Graph;
 using Sitko.FluentValidation.Tests.Data;
@@ -57,6 +58,23 @@ public class FluentGraphValidatorTests : BaseTest<ValidationTestScope>
 
         result.IsValid.Should().BeFalse();
         result.Results.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ValidatorResolvedFromDiUsesSameScopeAsGraphValidator()
+    {
+        var scope = await GetScopeAsync();
+        var graphValidator = scope.GetService<FluentGraphValidator>();
+        var validator = scope.GetService<global::FluentValidation.IValidator<ScopedDependencyModel>>();
+        var dependency = scope.GetService<ScopedDependency>();
+        var model = new ScopedDependencyModel { ScopeId = dependency.Id };
+
+        var directResult = await validator.ValidateAsync(model);
+        var graphResult = await graphValidator.TryValidateModelAsync(model);
+
+        directResult.IsValid.Should().BeTrue();
+        graphResult.IsValid.Should().BeTrue();
+        graphResult.Results.Should().ContainSingle();
     }
 
     [Fact]
@@ -199,5 +217,23 @@ public class FluentGraphValidatorTests : BaseTest<ValidationTestScope>
         result.ToString().Should()
             .Be(
                 "Validation errors: \nModel Sitko.FluentValidation.Tests.Data.FooModel\n\tId: 'Id' must not be empty.\n\tBarModels: 'Bar Models' must not be empty.");
+    }
+}
+
+public sealed class ScopedDependency
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}
+
+public sealed class ScopedDependencyModel
+{
+    public Guid ScopeId { get; init; }
+}
+
+public sealed class ScopedDependencyModelValidator : AbstractValidator<ScopedDependencyModel>
+{
+    public ScopedDependencyModelValidator(ScopedDependency dependency)
+    {
+        RuleFor(model => model.ScopeId).Equal(dependency.Id);
     }
 }

--- a/tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj
+++ b/tests/Sitko.FluentValidation.Tests/Sitko.FluentValidation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Sitko.FluentValidation.Tests/ValidationTestScope.cs
+++ b/tests/Sitko.FluentValidation.Tests/ValidationTestScope.cs
@@ -14,6 +14,7 @@ public class ValidationTestScope : BaseTestScope
     protected override IHostApplicationBuilder ConfigureServices(IHostApplicationBuilder builder, string name)
     {
         base.ConfigureServices(builder, name);
+        builder.Services.AddScoped<ScopedDependency>();
         builder.Services.AddFluentValidationExtensions();
         builder.Services.AddValidatorsFromAssemblyContaining<FluentGraphValidatorTests>();
         return builder;


### PR DESCRIPTION
This pull request migrates the `Sitko.FluentValidation` library to support only .NET 8 and .NET 10, upgrades its core dependency to FluentValidation 12, and updates documentation and project files accordingly. The changes are breaking, as support for all previous target frameworks is dropped. The implementation plan and design documentation are included to clarify the migration approach and compatibility considerations.

**Key changes:**

**Target Framework and Dependency Upgrades**
- The main library project (`Sitko.FluentValidation.csproj`) now targets only `net8.0` and `net10.0`, removing all previous TFMs and legacy dependencies like `IsExternalInit`. FluentValidation is upgraded to version 12, and Microsoft.Extensions.* dependencies are aligned per TFM. [[1]](diffhunk://#diff-c5f486dfe77ed8acd1885908285e49834c8709378b16b38e95ba67f67bfb2cacL4-R4) [[2]](diffhunk://#diff-c5f486dfe77ed8acd1885908285e49834c8709378b16b38e95ba67f67bfb2cacL25-R25) [[3]](diffhunk://#diff-c5f486dfe77ed8acd1885908285e49834c8709378b16b38e95ba67f67bfb2cacL39-R39)

**Codebase Compatibility with FluentValidation 12**
- The `FluentGraphValidator` class is updated to use `IServiceProvider` directly instead of a scoped provider, ensuring correct validator resolution and context creation under FluentValidation 12. [[1]](diffhunk://#diff-31065cdb70f4c0c77772c08780aba9030dc236eb294bd89707fc4dce4c73d15bL16-L24) [[2]](diffhunk://#diff-31065cdb70f4c0c77772c08780aba9030dc236eb294bd89707fc4dce4c73d15bL56-R56) [[3]](diffhunk://#diff-31065cdb70f4c0c77772c08780aba9030dc236eb294bd89707fc4dce4c73d15bL77-R77)

**Documentation and Release Metadata**
- The `README.md` is updated to reflect the new supported frameworks and clarify DI usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R34)
- The `CHANGELOG.md` gains a new entry for version 2.0.0, explicitly marking the breaking change, limited TFM support, and the FluentValidation 12 upgrade.

**Migration Planning and Design Documentation**
- A detailed migration plan (`2026-05-18-net10-fv12-upgrade.md`) and design specification (`2026-05-18-net10-fv12-design.md`) are added, outlining the rationale, steps, alternatives considered, compatibility strategy, and testing requirements for the upgrade. [[1]](diffhunk://#diff-487b673f3e8eaa20476c9f6acc661b548ba78dca9e00dc8bea9d460a2e609179R1-R251) [[2]](diffhunk://#diff-e0bec6334144348b2f25c707d96f0ec0fa766b6b29a8c1a44353419007748c51R1-R165)

**Test Suite Preparation**
- Test code and project files are updated to accommodate the new dependency versions and ensure future test coverage for both supported TFMs.

These changes collectively ensure that `Sitko.FluentValidation` is ready for modern .NET usage with FluentValidation 12, while making the breaking nature of the release clear to consumers.